### PR TITLE
Update game-page.html

### DIFF
--- a/src/pages/game-page.html
+++ b/src/pages/game-page.html
@@ -228,4 +228,3 @@
   </body>
   <footer class="copyright-info"></footer>
 </html>
-

--- a/src/pages/game-page.html
+++ b/src/pages/game-page.html
@@ -10,7 +10,82 @@
       name="keywords"
       content="Club Triton, tritons, UCSD, UC San Diego, virtual world, mmo, online game, free, free game"
     />
+    <style>
+      .modal {
+        display: none;
+        position: fixed;
+        z-index: 1000;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        overflow: auto;
+        background-color: rgba(0, 0, 0, 0.5);
+        justify-content: center;
+        align-items: center;
+      }
+
+      .modal.show {
+        display: flex;
+      }
+
+      .modal-content {
+        background-color: #f09d4a;
+        border: 0.5rem solid #2b2118;
+        border-radius: 20px;
+        padding: 30px;
+        text-align: center;
+        box-shadow:
+          0 0 20px rgba(0, 0, 0, 0.6),
+          inset 0 0 10px rgba(0, 0, 0, 0.4);
+        max-width: 400px;
+        margin: auto;
+        width: 80%;
+      }
+
+      .close-button {
+        margin-top: 20px;
+        padding: 6px 14px;
+        background-color: #a13c35;
+        color: white;
+        border: none;
+        border-radius: 8px;
+        font-size: 14px;
+        cursor: pointer;
+        box-shadow: 0 2px #2b2118;
+      }
+
+      .modal-content button:not(.close-button) {
+        margin: 10px;
+        padding: 16px 36px;
+        font-size: 20px;
+        background-color: #2b2118;
+        color: white;
+        border: none;
+        border-radius: 12px;
+        cursor: pointer;
+        box-shadow: 0 4px #111;
+        transition: background-color 0.2s;
+      }
+
+      .modal-content button:not(.close-button):hover {
+        background-color: #3a2a20;
+      }
+    </style>
   </head>
+  <!-- Modal HTML -->
+  <div id="gameModal" class="modal">
+    <div class="modal-content">
+      <h2 id="modalTitle">You Win!</h2>
+      <button onclick="location.reload()">Play Again</button>
+      <button onclick="window.location.href='home-page.html'">
+        Back to Home
+      </button>
+      <br />
+      <button id="closeModal" class="close-button">Close</button>
+    </div>
+  </div>
+
   <body>
     <main class="game-container">
       <div class="game-board">
@@ -125,6 +200,32 @@
         <a href="home-page.html" title="return to lobby"></a>
       </button>
     </main>
+    <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.5.1/dist/confetti.browser.min.js"></script>
+    <script defer>
+      document.addEventListener("DOMContentLoaded", function () {
+        const modal = document.getElementById("gameModal");
+        const modalTitle = document.getElementById("modalTitle");
+        const closeBtn = document.getElementById("closeModal");
+
+        closeBtn.addEventListener("click", () =>
+          modal.classList.remove("show"),
+        );
+
+        //Need to fix this part to match game logic
+        window.showGameResult = function (result) {
+          modal.classList.add("show");
+
+          if (result === "win") {
+            modalTitle.textContent = "🎉 You Win!";
+            confetti({ particleCount: 100, spread: 70, origin: { y: 0.6 } });
+          } else {
+            modalTitle.textContent = "😞 You Lose Bozo!";
+          }
+        };
+      });
+    </script>
   </body>
   <footer class="copyright-info"></footer>
 </html>
+


### PR DESCRIPTION
This commit should close #86

To run the function:
showGameResult('win')
-If running correctly, confetti should pop up. Menu will have play again button which will refresh the page, back to home button (takes user to homepage), and a close button that closes the pop up so they can see the ending game 

or

showGameResult('lose')
Same function as win without the confetti

Need help with:
The same modal style code is in style.css but doesn't pop up. Ive tried commenting out the style section in game-page.html but then the function doesn't work 
-Need to work game logic team to make sure the pop up triggers when user win/loses