### PR TITLE
Lighthouse job for GitHub Pages deployment

### DIFF
--- a/.github/workflows/lh.yml
+++ b/.github/workflows/lh.yml
@@ -18,9 +18,7 @@ jobs:
         uses: treosh/lighthouse-ci-action@v12
         with:
           urls: |
-            https://cse110-sp25-group13.github.io/dummy_repo/
-            https://cse110-sp25-group13.github.io/dummy_repo/expose.html
-            https://cse110-sp25-group13.github.io/dummy_repo/explore.html
+            https://cse110-sp25-group13.github.io/The_club_triton/src/pages/game-page.html
           budgetPath: ./budget.json
           uploadArtifacts: true
           temporaryPublicStorage: true


### PR DESCRIPTION
Closes #71 

edit lh.yml to run on the current gh pages url. we had copied over the same stuff from dummy_repo so it was still running on that.