### PR TITLE
Added ``-ai`` to ai triton-card element ids

### DIFF
--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -81,7 +81,9 @@ function drawCards(count, ai) {
     deck.splice(randomIndex, 1);
     //create triton card el
     const tritonCard = document.createElement("triton-card");
-    tritonCard.id = `tritonCard-${cardObj.id}`;
+    tritonCard.id = ai
+      ? `tritonCard-${cardObj.id}-ai`
+      : `tritonCard-${cardObj.id}`;
     //tritonCard.back_image = cardObj.back_image_placeholder;
     tritonCard.name = cardObj.name;
     tritonCard.rank = cardObj.ranking;
@@ -176,7 +178,7 @@ async function playRound(playerCardId) {
   //removeCardFromSlot(playerCard.id, playerDeckEl);
 
   // Animate AI card moving
-  const aiCardEl = document.getElementById(`tritonCard-${aiCard.id}`);
+  const aiCardEl = document.getElementById(`tritonCard-${aiCard.id}-ai`);
   console.log("[playRound] animate AI from", aiCardEl, "to", chosenAiSlot);
   try {
     await animateCardMove(aiCardEl, chosenAiSlot);


### PR DESCRIPTION
Closes #134 

![image](https://github.com/user-attachments/assets/4822b754-4bcf-4d2c-a187-99c524e026d5)

Name conflicts occur when trying to animate the cards, since they are being queried by IDs which were not unique to AI and player. This PR simply adds ``-ai`` to the triton-card element ID for the AI cards. I'm not able to reproduce the bug consistently, so we should specifically check for this in the E2E test.