### PR TITLE
fix(assets): Resolve image loading issues on GitHub Pages by using dynamic base path

### DIFF
--- a/src/card/triton-card.js
+++ b/src/card/triton-card.js
@@ -2,6 +2,22 @@
  * TritonCard is a custom web component representing a card with a front and back.
  * @const {Map<string,string>}
  */
+
+// Dynamic base path determination for consistent asset loading
+const getBasePath = () => {
+  let path = '';
+  if (window.location.hostname.includes('github.io')) {
+    const pathSegments = window.location.pathname.split('/');
+    if (pathSegments.length > 1 && pathSegments[1] && pathSegments[1].toLowerCase() === 'the_club_triton') {
+      path = '/' + pathSegments[1];
+    }
+  }
+  return path;
+};
+
+const TRITON_CARD_BASE_PATH = getBasePath();
+console.log("TritonCard Base Path:", TRITON_CARD_BASE_PATH);
+
 const TYPE_COLORS = {
   structure: "#003A70", // Dark blue
   dining: "#FFCD00", // Yellow
@@ -20,11 +36,11 @@ const TYPE_COLORS = {
  * @const {Map<string,string>} TYPE_BORDER
  */
 const TYPE_BORDER = {
-  structure: "/src/assets/imgs/card_borders/default-card-base.png",
-  dining: "/src/assets/imgs/card_borders/blue-card-base.png",
-  mascot: "/src/assets/imgs/card_borders/dark-card-base.png",
-  living: "/src/assets/imgs/card_borders/green-card-base.png",
-  default: "/src/assets/imgs/card_borders/yellow-card-base.png",
+  structure: `${TRITON_CARD_BASE_PATH}/src/assets/imgs/card_borders/default-card-base.png`,
+  dining: `${TRITON_CARD_BASE_PATH}/src/assets/imgs/card_borders/blue-card-base.png`,
+  mascot: `${TRITON_CARD_BASE_PATH}/src/assets/imgs/card_borders/dark-card-base.png`,
+  living: `${TRITON_CARD_BASE_PATH}/src/assets/imgs/card_borders/green-card-base.png`,
+  default: `${TRITON_CARD_BASE_PATH}/src/assets/imgs/card_borders/yellow-card-base.png`,
 };
 
 /**
@@ -32,7 +48,7 @@ const TYPE_BORDER = {
  */
 class TritonCard extends HTMLElement {
   //should never use default anyway
-  static default_card_border_path = "./assets/default-card-base.png"; // Update this element to have a different default border
+  static default_card_border_path = `${TRITON_CARD_BASE_PATH}/src/assets/imgs/card_borders/default-card-base.png`; // Update this element to have a different default border
   #card;
 
   /**
@@ -216,7 +232,17 @@ class TritonCard extends HTMLElement {
    */
   set front_image(src) {
     const img = this.#card.querySelector("#img-card-front");
-    if (img) img.src = src;
+    if (img) {
+      if (src) {
+        // If src starts with '/src/', it's a project-relative path from cards.json - add basePath
+        // Otherwise, treat as already properly formatted URL or relative path
+        img.src = src.startsWith('/src/') ? `${TRITON_CARD_BASE_PATH}${src}` : src;
+        img.alt = "Card Front";
+      } else {
+        img.src = "";
+        img.alt = "Card front image placeholder";
+      }
+    }
   }
 
   /**
@@ -226,7 +252,17 @@ class TritonCard extends HTMLElement {
    */
   set back_image(src) {
     const img = this.#card.querySelector("#img-card-back");
-    if (img) img.src = src;
+    if (img) {
+      if (src) {
+        // If src starts with '/src/', it's a project-relative path from cards.json - add basePath
+        // Otherwise, treat as already properly formatted URL or relative path
+        img.src = src.startsWith('/src/') ? `${TRITON_CARD_BASE_PATH}${src}` : src;
+        img.alt = "Card Back";
+      } else {
+        img.src = "";
+        img.alt = "Card back image placeholder";
+      }
+    }
   }
 
   /**

--- a/src/card/triton-card.js
+++ b/src/card/triton-card.js
@@ -5,11 +5,15 @@
 
 // Dynamic base path determination for consistent asset loading
 const getBasePath = () => {
-  let path = '';
-  if (window.location.hostname.includes('github.io')) {
-    const pathSegments = window.location.pathname.split('/');
-    if (pathSegments.length > 1 && pathSegments[1] && pathSegments[1].toLowerCase() === 'the_club_triton') {
-      path = '/' + pathSegments[1];
+  let path = "";
+  if (window.location.hostname.includes("github.io")) {
+    const pathSegments = window.location.pathname.split("/");
+    if (
+      pathSegments.length > 1 &&
+      pathSegments[1] &&
+      pathSegments[1].toLowerCase() === "the_club_triton"
+    ) {
+      path = "/" + pathSegments[1];
     }
   }
   return path;
@@ -236,7 +240,9 @@ class TritonCard extends HTMLElement {
       if (src) {
         // If src starts with '/src/', it's a project-relative path from cards.json - add basePath
         // Otherwise, treat as already properly formatted URL or relative path
-        img.src = src.startsWith('/src/') ? `${TRITON_CARD_BASE_PATH}${src}` : src;
+        img.src = src.startsWith("/src/")
+          ? `${TRITON_CARD_BASE_PATH}${src}`
+          : src;
         img.alt = "Card Front";
       } else {
         img.src = "";
@@ -256,7 +262,9 @@ class TritonCard extends HTMLElement {
       if (src) {
         // If src starts with '/src/', it's a project-relative path from cards.json - add basePath
         // Otherwise, treat as already properly formatted URL or relative path
-        img.src = src.startsWith('/src/') ? `${TRITON_CARD_BASE_PATH}${src}` : src;
+        img.src = src.startsWith("/src/")
+          ? `${TRITON_CARD_BASE_PATH}${src}`
+          : src;
         img.alt = "Card Back";
       } else {
         img.src = "";

--- a/src/scripts/card-system.js
+++ b/src/scripts/card-system.js
@@ -42,12 +42,16 @@ export { initDB, getAllCards, basePath };
 
 // Dynamic base path determination for asset loading
 // This solves the GitHub Pages vs local development path issues
-let basePath = '';
-if (window.location.hostname.includes('github.io')) {
-  const pathSegments = window.location.pathname.split('/');
+let basePath = "";
+if (window.location.hostname.includes("github.io")) {
+  const pathSegments = window.location.pathname.split("/");
   // Check if we're in a repository subdirectory (typical for GitHub Pages)
-  if (pathSegments.length > 1 && pathSegments[1] && pathSegments[1].toLowerCase() === 'the_club_triton') {
-    basePath = '/' + pathSegments[1];
+  if (
+    pathSegments.length > 1 &&
+    pathSegments[1] &&
+    pathSegments[1].toLowerCase() === "the_club_triton"
+  ) {
+    basePath = "/" + pathSegments[1];
   }
 }
 console.log("Asset Base Path determined:", basePath);
@@ -77,9 +81,7 @@ async function fetchCardDataFromJson(jsonFilePath) {
       );
     }
     const jsonData = await response.json(); // Parse JSON response body
-    console.log(
-      `Successfully fetched and parsed card data from ${fullPath}`,
-    );
+    console.log(`Successfully fetched and parsed card data from ${fullPath}`);
     return jsonData;
   } catch (error) {
     console.error(

--- a/src/scripts/card-system.js
+++ b/src/scripts/card-system.js
@@ -38,7 +38,19 @@
 // or module.exports = initialCardData; // If using CommonJS (Node.js)
 // For now, just define it in this file.
 
-export { initDB, getAllCards };
+export { initDB, getAllCards, basePath };
+
+// Dynamic base path determination for asset loading
+// This solves the GitHub Pages vs local development path issues
+let basePath = '';
+if (window.location.hostname.includes('github.io')) {
+  const pathSegments = window.location.pathname.split('/');
+  // Check if we're in a repository subdirectory (typical for GitHub Pages)
+  if (pathSegments.length > 1 && pathSegments[1] && pathSegments[1].toLowerCase() === 'the_club_triton') {
+    basePath = '/' + pathSegments[1];
+  }
+}
+console.log("Asset Base Path determined:", basePath);
 
 let db; // Global variable to hold the database instance (for simplicity; in real projects, use better state management)
 let initPromise = null; // Singleton pattern to ensure only one initialization happens
@@ -49,12 +61,15 @@ const STORE_NAME_OWNED = "playerOwnedCards"; // Store player owned card IDs
 
 /**
  * Asynchronously fetch card data from the specified JSON file path.
- * @param {string} jsonFilePath - The path to the JSON file.
+ * @param {string} jsonFilePath - The path to the JSON file (relative to project root).
  * @returns {Promise<Array<Object>>} A Promise that resolves to an array of card objects.
  */
 async function fetchCardDataFromJson(jsonFilePath) {
   try {
-    const response = await fetch(jsonFilePath);
+    // Construct full path using basePath for proper asset loading
+    const fullPath = basePath + jsonFilePath;
+    console.log(`Fetching JSON from: ${fullPath}`);
+    const response = await fetch(fullPath);
     if (!response.ok) {
       // If HTTP status code is not 2xx (e.g., 404 Not Found, 500 Server Error)
       throw new Error(
@@ -63,7 +78,7 @@ async function fetchCardDataFromJson(jsonFilePath) {
     }
     const jsonData = await response.json(); // Parse JSON response body
     console.log(
-      `Successfully fetched and parsed card data from ${jsonFilePath}`,
+      `Successfully fetched and parsed card data from ${fullPath}`,
     );
     return jsonData;
   } catch (error) {
@@ -220,12 +235,9 @@ function initDB() {
       );
 
       try {
-        const basePath = window.location.hostname.includes("github.io")
-          ? "/The_club_triton"
-          : "";
         // After database opens successfully, check and populate data if needed
-        // populateDataIfEmpty now only handles STORE_NAME_CARDS and fills it from JSON
-        await populateDataIfEmpty(db, STORE_NAME_CARDS, `${basePath}/src/card/cards.json`);
+        // Use dynamic basePath for proper JSON loading across environments
+        await populateDataIfEmpty(db, STORE_NAME_CARDS, "/src/card/cards.json");
         console.log(
           "Database initialization and data population check complete.",
         );


### PR DESCRIPTION
**Title:** `fix(assets): Resolve image loading issues on GitHub Pages by using dynamic base path`


**Description:**

This PR addresses and resolves issues where card images (borders, faces) were displaying correctly in the local development environment but failed to load (404 errors) when deployed to GitHub Pages.

**Problem Solved:**
The root cause was identified as the use of absolute paths (e.g., `/src/...`) for image assets, which do not correctly account for the repository name being part of the path in the GitHub Pages URL (e.g., `/<repo_name>/src/...`).

**Solution Implemented:**

1.  **Dynamic `basePath` Detection:**
    *   JavaScript logic (primarily in `card-system.js` and/or `triton-card.js`) has been added to dynamically determine the correct base path for assets depending on the environment (empty for `localhost`, `/<repo_name>` for GitHub Pages).
2.  **Path Adjustments:**
    *   Image paths in `cards.json` (`front_image_placeholder`, `back_image_placeholder`) are now defined as paths relative to the project root (e.g., starting with `/src/assets/...`).
    *   The `triton-card.js` component (for its internal border image paths in `TYPE_BORDER` and `default_card_border_path`, and for image setters) now prepends the dynamic `basePath` to these root-relative paths to construct the correct, full URL for images.
    *   The `fetch` call for `cards.json` in `card-system.js` has also been updated to use this `basePath` logic to ensure it loads correctly in both environments.

**Impact:**

*   Card border images and card face images (from placeholders in `cards.json`) should now load correctly both in the local development environment and on the deployed GitHub Pages site.
*   This makes testing and demonstration on GitHub Pages reliable.

**How to Test:**

1.  Checkout this branch: `your-feature-branch-name`
2.  **Test Locally:**
    *   Run the local development server (e.g., `npx http-server . -p 8080`).
    *   Open `src/card/demo.html` (or other relevant test pages).
    *   Verify all card images (borders, faces/placeholders) display correctly. Check the browser console and network tab for any 404 errors related to images or `cards.json`.
3.  **Test on GitHub Pages (after this PR is merged to `develop` and GH Pages redeploys):**
    *   Navigate to the deployed GitHub Pages URL for `demo.html` (or relevant page).
    *   Verify all card images display correctly. Check the browser console and network tab for any 404 errors. The image URLs in the network tab should now correctly include the repository name in the path.

**Files Modified (主要):**

*   `src/scripts/card-system.js` (for `basePath` logic and `fetch` path)
*   `src/card/triton-card.js` (for `basePath` usage in image paths)
