### PR TITLE
Feature/selection min for buttons fix

### DIFF
--- a/src/pages/collection-page.html
+++ b/src/pages/collection-page.html
@@ -75,6 +75,7 @@
           if (deckCountElement) {
             deckCountElement.textContent = activeDeckIds.length;
           }
+          updateButtonState(activeDeckIds.length);
 
           if (allCards && allCards.length > 0) {
             allCards.forEach((data) => {
@@ -123,6 +124,24 @@
         }
       }
 
+      /**
+       * Update "PLAY" and "ENTER GAME" button states according to card selection minimum
+      */
+      function updateButtonState(deckSize) {
+        const playNavBtn = document.querySelector("#play-nav-btn"); // TEMP for nav button
+        console.log("updateButtonState called. playNavBtn:", playNavBtn);
+
+        // Only disable if deck size is 1–9 (i.e. not empty but not enough)
+        const disableButtons = deckSize > 0 && deckSize < 10;
+
+        enterGameButton.disabled = disableButtons;
+        if (playNavBtn) playNavBtn.disabled = disableButtons;
+
+        const tooltip = disableButtons ? "Select at least 10 cards to enter the game." : "";
+        enterGameButton.title = tooltip;
+        if (playNavBtn) playNavBtn.title = tooltip;
+      }
+
       // Toggle card in active deck status
       async function toggleCardInDeck(cardId) {
         try {
@@ -157,14 +176,20 @@
             '<p class="error-message">Failed to initialize card database.</p>';
         });
 
+      // Navbar load event listener, to make sure "PLAY" button recieves logic
+      document.addEventListener("navbar-loaded", async () => {
+        const activeDeckIds = await getOwnedCardIds();
+        updateButtonState(activeDeckIds.length);
+        console.log("Navbar loaded; play button updated.");
+      });
       // Enter Game button event
       enterGameButton.addEventListener("click", async () => {
         try {
           const activeDeckIds = await getOwnedCardIds();
-          if (activeDeckIds.length === 0) {
-            alert(
-              "Please select at least one card for your deck before entering the game!",
-            );
+          
+          // Alert and don't allow game enter if they are using manual deck and don't have min cards
+          if (activeDeckIds.length > 0 && activeDeckIds.length < 10) {
+            alert("You must select at least 10 cards to enter the game.");
             return;
           }
 

--- a/src/pages/collection-page.html
+++ b/src/pages/collection-page.html
@@ -1,6 +1,10 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <script
+      src="https://kit.fontawesome.com/186103375e.js"
+      crossorigin="anonymous"
+    ></script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Card Collection & Deck Builder - TritonCard</title>

--- a/src/pages/navbar.html
+++ b/src/pages/navbar.html
@@ -22,19 +22,19 @@
         />
       </li>
       <li class="nav-button">
-        <a href="../pages/home-page.html"
-          ><i class="fa-solid fa-house"></i> Home</a
-        >
+        <a href="../pages/home-page.html">
+          <i class="fa-solid fa-house"></i> Home
+        </a>
       </li>
       <li class="nav-button">
-        <a href="../pages/game-page.html"
-          ><i class="fa-solid fa-gamepad"></i> Play</a
-        >
+        <button id="play-nav-btn" onclick="location.href='../pages/game-page.html'">
+          <i class="fa-solid fa-gamepad"></i> Play
+        </button>
       </li>
       <li class="nav-button">
-        <a href="../pages/collection-page.html"
-          ><i class="fa-solid fa-database"></i> Collection</a
-        >
+        <a href="../pages/collection-page.html">
+          <i class="fa-solid fa-database"></i> Collection
+        </a>
       </li>
     </ul>
   </nav>

--- a/src/scripts/load-navbar.js
+++ b/src/scripts/load-navbar.js
@@ -5,6 +5,8 @@ document.addEventListener("DOMContentLoaded", () => {
     .then((res) => res.text())
     .then((html) => {
       navbarContainer.innerHTML = html;
+      // Dispatch event so collection-page knows navbar is ready
+      document.dispatchEvent(new Event("navbar-loaded"));
     })
     .catch((err) => {
       console.error("Navbar failed to load:", err);

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -121,18 +121,18 @@ function drawCards(count, ai, cardPool = null) {
       ? `tritonCard-${cardObj.id}-ai`
       : `tritonCard-${cardObj.id}`;
     //tritonCard.back_image = cardObj.back_image_placeholder;
-    //tritonCard.name = cardObj.name;
-    //tritonCard.rank = cardObj.ranking;
-    //tritonCard.type = cardObj.type;
-    //tritonCard.description = cardObj.description;
-    //tritonCard.rarity = cardObj.rarity;
+    tritonCard.name = cardObj.name;
+    tritonCard.rank = cardObj.ranking;
+    tritonCard.type = cardObj.type;
+    tritonCard.description = cardObj.description;
+    tritonCard.rarity = cardObj.rarity;
 
     if (ai) {
-      tritonCard.dataset.name = cardObj.name;
-      tritonCard.dataset.rank = cardObj.ranking;
-      tritonCard.dataset.type = cardObj.type;
-      tritonCard.dataset.description = cardObj.description;
-      tritonCard.dataset.rarity = cardObj.rarity;
+      //tritonCard.dataset.name = cardObj.name;
+      //tritonCard.dataset.rank = cardObj.ranking;
+      //tritonCard.dataset.type = cardObj.type;
+      //tritonCard.dataset.description = cardObj.description;
+      //tritonCard.dataset.rarity = cardObj.rarity;
       let targetSlot = aiDeckEl[i];
       if (targetSlot.querySelector("triton-card")) {
         targetSlot = aiDeckEl.find(
@@ -145,11 +145,11 @@ function drawCards(count, ai, cardPool = null) {
         targetSlot.appendChild(tritonCard);
       }
     } else {
-      tritonCard.name = cardObj.name;
-      tritonCard.rank = cardObj.ranking;
-      tritonCard.type = cardObj.type;
-      tritonCard.description = cardObj.description;
-      tritonCard.rarity = cardObj.rarity;
+      //tritonCard.name = cardObj.name;
+      //tritonCard.rank = cardObj.ranking;
+      //tritonCard.type = cardObj.type;
+      //tritonCard.description = cardObj.description;
+      //tritonCard.rarity = cardObj.rarity;
       tritonCard.addEventListener("click", () => {
         playRound(cardObj.id);
       });

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -121,13 +121,18 @@ function drawCards(count, ai, cardPool = null) {
       ? `tritonCard-${cardObj.id}-ai`
       : `tritonCard-${cardObj.id}`;
     //tritonCard.back_image = cardObj.back_image_placeholder;
-    tritonCard.name = cardObj.name;
-    tritonCard.rank = cardObj.ranking;
-    tritonCard.type = cardObj.type;
-    tritonCard.description = cardObj.description;
-    tritonCard.rarity = cardObj.rarity;
+    //tritonCard.name = cardObj.name;
+    //tritonCard.rank = cardObj.ranking;
+    //tritonCard.type = cardObj.type;
+    //tritonCard.description = cardObj.description;
+    //tritonCard.rarity = cardObj.rarity;
 
     if (ai) {
+      tritonCard.dataset.name = cardObj.name;
+      tritonCard.dataset.rank = cardObj.ranking;
+      tritonCard.dataset.type = cardObj.type;
+      tritonCard.dataset.description = cardObj.description;
+      tritonCard.dataset.rarity = cardObj.rarity;
       let targetSlot = aiDeckEl[i];
       if (targetSlot.querySelector("triton-card")) {
         targetSlot = aiDeckEl.find(
@@ -136,10 +141,15 @@ function drawCards(count, ai, cardPool = null) {
       }
       if (targetSlot) {
         //can you make it not show any info on the cards? supposed to be unknown to player?
-        tritonCard.front_image = cardObj.front_image_placeholder;
+        tritonCard.front_image = cardObj.back_image_placeholder;
         targetSlot.appendChild(tritonCard);
       }
     } else {
+      tritonCard.name = cardObj.name;
+      tritonCard.rank = cardObj.ranking;
+      tritonCard.type = cardObj.type;
+      tritonCard.description = cardObj.description;
+      tritonCard.rarity = cardObj.rarity;
       tritonCard.addEventListener("click", () => {
         playRound(cardObj.id);
       });

--- a/src/scripts/script.js
+++ b/src/scripts/script.js
@@ -141,7 +141,7 @@ function drawCards(count, ai, cardPool = null) {
       }
       if (targetSlot) {
         //can you make it not show any info on the cards? supposed to be unknown to player?
-        tritonCard.front_image = cardObj.back_image_placeholder;
+        tritonCard.front_image = cardObj.front_image_placeholder;
         targetSlot.appendChild(tritonCard);
       }
     } else {

--- a/src/styles/collection-page-styles.css
+++ b/src/styles/collection-page-styles.css
@@ -356,3 +356,10 @@ footer p {
     font-size: 0.9rem;
   }
 }
+
+#enter-game-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none !important;
+  background-color: rgba(0, 0, 0, 0.1);
+}

--- a/src/styles/navbar.css
+++ b/src/styles/navbar.css
@@ -44,7 +44,9 @@
   display: inline-block;
 }
 
-.navbar a {
+.navbar a,
+.navbar button {
+  all: unset;
   color: black;
   text-decoration: none;
   font-family: "Luckiest Guy", cursive;
@@ -55,11 +57,25 @@
   transition:
     transform 0.2s ease,
     background-color 0.2s ease;
+  cursor: pointer;
 }
 
 .navbar a:hover {
   transform: scale(1.1);
   background-color: rgba(255, 255, 255, 0.2);
+}
+
+.navbar button:hover {
+  transform: scale(1.1);
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+#play-nav-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: none !important;
+  background: none;
+  color: black;
 }
 
 /* END OF NAVBAR THINGS */


### PR DESCRIPTION
Added following 3 states for the "Play" button in the navbar and "Enter Game" button at the bottom of the collection page:

1. 0 cards are selected: "ENTER GAME" and "PLAY" buttons direct player to the game page with the default (full deck or whatever it was before)
2. At least 1 card is selected but less than the minimum 10 cards are selected: "ENTER GAME" and "PLAY" buttons are disabled, and have a tooltip "Select at least 10 cards to enter the game." when you hover over them with your cursor
3. At least the minimum 10 cards are selected: "ENTER GAME" and "PLAY" buttons are enabled and direct the player to the game page with their selected cards as the deck

While the buttons are disabled, the "Play" button is faded, and the "Enter Game" button is slightly greyed in the background and faded. Cursor has the "not allowed" icon when hovering over the disabled buttons.

FontAwesome script also added in collection page html since icons weren't loading.